### PR TITLE
NB-573 Added Academic Host Flag

### DIFF
--- a/src/main/java/com/neverbounce/api/model/Flag.java
+++ b/src/main/java/com/neverbounce/api/model/Flag.java
@@ -52,6 +52,11 @@ public enum Flag {
   GOVERNMENT_HOST("The input given is a government email"),
   
   /**
+   * Academic Host.
+   */
+  ACADEMIC_HOST("The input given is a acedemic email"),
+
+  /**
    * Acedemic Host.
    */
   ACEDEMIC_HOST("The input given is a acedemic email"),


### PR DESCRIPTION
[NB-573](https://discoverorg.atlassian.net/browse/NB-573): Fix the typo for acedemic_host in neverbounce core